### PR TITLE
Making filreader save for no conflicting mode

### DIFF
--- a/filereader.js
+++ b/filereader.js
@@ -47,7 +47,7 @@
     if (typeof(jQuery) !== "undefined") {
         jQuery.fn.fileReaderJS = function(opts) {
             return this.each(function() {
-                if ($(this).is("input")) {
+                if (jQuery(this).is("input")) {
                     setupInput(this, opts);
                 }
                 else {


### PR DESCRIPTION
When people use jQuery in no conflict mode and another library (eg. mootools) is taking the $ function over, filereader will crash. This change will use jQuery instead.
